### PR TITLE
ci: enable justfile validation

### DIFF
--- a/recipes/common-files.yml
+++ b/recipes/common-files.yml
@@ -19,7 +19,7 @@ modules:
           url: https://github.com/googlefonts/noto-emoji/raw/main/fonts/NotoColorEmoji.ttf
 
   - type: justfiles
-    validate: false
+    validate: true
     include:
     - activate_webcam.just
     - kill_citrix.just


### PR DESCRIPTION
## Summary

Enable the BlueBuild justfiles module’s built-in validation so malformed recipes fail during CI instead of reaching an image.

## Verification

- all 22 tracked justfiles parse successfully with `just 1.58.0`
- `git diff --check` passes
- exactly one line changed in `recipes/common-files.yml`