### PR TITLE
ci: avoid duplicate builds for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
         "00 06 * * *" # build at 06:00 UTC every day
         # (20 minutes after last ublue images start building)
   push:
+    branches:
+      - main
+      - dev
     paths-ignore: # don't rebuild if only documentation has changed
       - "**.md"
 


### PR DESCRIPTION
## Summary

- limit push-triggered image builds to `main` and `dev`
- keep pull-request validation builds unchanged
- prevent feature branches from starting both a push matrix and a PR matrix

## Expected behavior

- feature branch with PR: one three-variant PR matrix
- push to `main`: one three-variant release-candidate matrix
- push to `dev`: the existing NVIDIA-only matrix
- schedules and manual dispatches remain unchanged

## Verification

- `actionlint .github/workflows/build.yml`
- `git diff --check`
- trigger assertions verify `main`/`dev` push branches and the existing PR Markdown filter