### PR TITLE
docs: explain early Surface repository setup

### DIFF
--- a/recipes/recipe-dx-surface.yml
+++ b/recipes/recipe-dx-surface.yml
@@ -18,7 +18,6 @@ modules:
     repos:
       files:
         - linux-surface.repo
-        - kompassos.repo
 
   - type: script
     scripts:

--- a/recipes/recipe-dx-surface.yml
+++ b/recipes/recipe-dx-surface.yml
@@ -13,11 +13,13 @@ alt-tags:
 modules:
   - from-file: common-files.yml
 
-  # Surface Linux kernel repo and install (before common scripts)
+  # Surface install needs both repos before common-dnf.yml runs:
+  # linux-surface provides the kernel; kompassos provides Fedora-compatible libwacom.
   - type: dnf
     repos:
       files:
         - linux-surface.repo
+        - kompassos.repo
 
   - type: script
     scripts:


### PR DESCRIPTION
## Summary
- document why the Surface recipe loads both repositories before `common-dnf.yml`
- preserve the early `kompassos.repo` setup required for Fedora-compatible `libwacom-surface`

## Evidence
- without the early repo, Fedora 44 selected `libwacom-surface` 2.17 from the Fedora 43 linux-surface repository and failed dependency resolution
- the previous successful build selected `libwacom-surface` 2.18 for Fedora 44 from `kompassos.repo`

## Verification
- YAML lint passes
- `git diff --check` passes
- image-build matrix reruns on this update