### PR TITLE
fix: handle already-correct user UID

### DIFF
--- a/files/justfiles/fix_user_uid.just
+++ b/files/justfiles/fix_user_uid.just
@@ -14,16 +14,16 @@ fix-uid:
     echo "${yellow}KompassOS UID Fix${normal}"
     echo ""
 
-    if getent passwd $new_uid > /dev/null 2>&1; then
-        existing=$(getent passwd $new_uid | cut -d: -f1)
-        echo "${red}UID $new_uid is already in use by '$existing', aborting.${normal}"
-        exit 1
-    fi
-
     current_uid=$(id -u $username)
     if [ "$current_uid" -eq "$new_uid" ]; then
         echo "${green}$username already has UID $new_uid, nothing to do.${normal}"
         exit 0
+    fi
+
+    if getent passwd $new_uid > /dev/null 2>&1; then
+        existing=$(getent passwd $new_uid | cut -d: -f1)
+        echo "${red}UID $new_uid is already in use by '$existing', aborting.${normal}"
+        exit 1
     fi
 
     echo "Current UID of ${blue}$username${normal}: ${red}$current_uid${normal}"


### PR DESCRIPTION
## Summary
- check the current user UID before testing whether UID 1000 is occupied
- return successfully when the current user already has UID 1000
- preserve the existing conflict check for other users

## Verification
- exercised the recipe with mocked commands for an already-correct user and an occupied target UID
- `just --justfile files/justfiles/fix_user_uid.just --summary`
- `just --justfile files/justfiles/fix_user_uid.just --dry-run fix-uid`
- `git diff --check`